### PR TITLE
DD-349 including JS library

### DIFF
--- a/plugins/contexts/sticky_elements_context_reaction.inc
+++ b/plugins/contexts/sticky_elements_context_reaction.inc
@@ -42,6 +42,9 @@ class sticky_elements_context_reaction extends context_reaction {
       }
       if ($elements = $this->fetch_from_context($context, 'values')) {
         drupal_add_js(array('sticky_elements' => $elements), 'setting');
+        drupal_add_js(libraries_get_path('sticky_elements_js') .'/dist/stickyElement.js', array(
+          'attributes' => array('async' => 'async'),
+        ));
       }
     }
   }

--- a/sticky_elements.make
+++ b/sticky_elements.make
@@ -1,0 +1,9 @@
+api = 2
+core = 7.x
+
+; Javascript functionality to make page elements sticky, when defined by a context.
+libraries[sticky_elements_js][type] = library
+libraries[sticky_elements_js][download][type] = git
+libraries[sticky_elements_js][download][url] = git@github.com:dennisinteractive/sticky_elements_js.git
+libraries[sticky_elements_js][download][tag] = 7.x-0.3
+libraries[sticky_elements_js][directory_name] = sticky_elements_js


### PR DESCRIPTION
* Includes `dennisinteractive/sticky_elements_js` JS library

You might want to use regular semver tags for the JS library, rather than use `7.x...` Drupal prefix