### PR TITLE
DD-414 added conditional to ensure Drupal JS object is initialised

### DIFF
--- a/js/sticky_elements_init.js
+++ b/js/sticky_elements_init.js
@@ -1,39 +1,41 @@
 (function () {
-  Drupal.behaviors.stickyElementsBehavior = {
-    attach: function (context, settings) {
+  if (Drupal) {
+    Drupal.behaviors.stickyElementsBehavior = {
+      attach: function (context, settings) {
 
-      function initSticky() {
-        // Main init entry
-        StickyElements.init(settings.sticky_elements);
+        function initSticky() {
+          // Main init entry
+          StickyElements.init(settings.sticky_elements);
 
-        // We rejig the slot on in the event that a DFP slot is being targeted
-        googletag.pubads().addEventListener('slotRenderEnded', function(event) {
-          let slotSelector = '#' + event.slot.getSlotElementId();
-          let slotElement = document.querySelector(slotSelector);
+          // We rejig the slot on in the event that a DFP slot is being targeted
+          googletag.pubads().addEventListener('slotRenderEnded', function(event) {
+            let slotSelector = '#' + event.slot.getSlotElementId();
+            let slotElement = document.querySelector(slotSelector);
 
-          settings.sticky_elements.elements.forEach(element => {
-              let slotChild = element.target.querySelector(slotSelector);
-              
-              if(element.target === slotElement || slotChild){
-                if(element.type !== 'timeout') {
-                  this.setHeight(element.parent, element.value);
-                }else{
-                  this.setHeight(element.target);
+            settings.sticky_elements.elements.forEach(element => {
+                let slotChild = element.target.querySelector(slotSelector);
+
+                if(element.target === slotElement || slotChild){
+                  if(element.type !== 'timeout') {
+                    this.setHeight(element.parent, element.value);
+                  }else{
+                    this.setHeight(element.target);
+                  }
+                  this.setAllEnds(element);
                 }
-                this.setAllEnds(element);
-              }
-          });
-        }.bind(StickyElements));
-      }
+            });
+          }.bind(StickyElements));
+        }
 
-      // If StickyElements is loaded then go for it. If not wait for the load event.
-      if(StickyElements) {
-        initSticky();
-      }else {
-        document.addEventListener("sticky-element:load", function(event){
+        // If StickyElements is loaded then go for it. If not wait for the load event.
+        if(StickyElements) {
           initSticky();
-        }.bind(window));
+        }else {
+          document.addEventListener("sticky-element:load", function(event){
+            initSticky();
+          }.bind(window));
+        }
       }
-    }
-  };
+    };
+  }
 })();


### PR DESCRIPTION
When used in Expert Reviews this throws a Drupal is undefined error. Adding a conditional means the script won't execute until the Drupal JS object is initialised.